### PR TITLE
Match img height with boxes in results cont

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -156,9 +156,9 @@
           <div class="col-sm-7 col-lg-6 col-12 text-end p-0 h-100">
             {% with sticker_unlocked=score|is_sticker_unlocked %}
             <img src="{% static 'media/images/stickers/16x9/level-'%}{{ score.level.index }}-{{sticker_unlocked}}.svg" alt="Sticker"
-              class="img-fluid h-100 d-none d-lg-inline" />
+              class="h-100 d-none d-lg-inline" />
             <img src="{% static 'media/images/stickers/1x1/level-'%}{{ score.level.index }}-{{sticker_unlocked}}.svg" alt="Sticker"
-              class="img-fluid h-100 d-none d-lg-none d-sm-inline " />
+              class="h-100 d-none d-lg-none d-sm-inline " />
             {% endwith %}
           </div>
         </div>


### PR DESCRIPTION
- It's easier to match the total height of the container than the img-fluid parameter.
- It would be possible to replace the 16x9 img by 1x1 in a certain area where the banner is outside the page.